### PR TITLE
global posts_info to resolve an undefined name

### DIFF
--- a/display.py
+++ b/display.py
@@ -58,4 +58,5 @@ def display_to_terminal(posts_info, display_color):
             draw(img_path, posts_info[filename])
 
 if __name__ == '__main__':
+    global posts_info
     display_to_terminal(posts_info)


### PR DESCRIPTION
flake8 testing of https://github.com/billcccheng/instagram-terminal-news-feed on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./display.py:61:25: F821 undefined name 'posts_info'
    display_to_terminal(posts_info)
                        ^
1     F821 undefined name 'posts_info'
```