### PR TITLE
Added images/ folder to the repo with a .gitkeep file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 __pycache__
 *.pyc
 credential.json
-images/*.jpg
+images/*
+!images/.gitkeep


### PR DESCRIPTION
When running the app the first time after cloning the repo, the script failed in a FileNotFoundError for a missing images/-folder.

Added the images folder to the repository with a .gitkeep file,  altered the .gitignore rules so that everything else in the folder but the .gitkeep file will be ignored.